### PR TITLE
Fix filter with double negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.2] - 2022-01-03
+
+- Bug fix: doesn't run the filter at the right time
+
 ## [1.1.1] - 2022-01-03
 
 - Add Github URL to the PyPi page

--- a/looker_ingestion/sync_data.py
+++ b/looker_ingestion/sync_data.py
@@ -142,7 +142,7 @@ def extract_data(json_filename, aws_storage_bucket_name=BUCKET_NAME, aws_server_
         ## if the filter already exists, dont run it
         ## if there's no datetime, don't run it
         ## if there no datetime defined
-        if is_incremental_extraction and filters.get(datetime_index) is not None:
+        if is_incremental_extraction and filters.get(datetime_index) is None:
             try:
                 int(default_days)
             except ValueError:
@@ -155,7 +155,7 @@ def extract_data(json_filename, aws_storage_bucket_name=BUCKET_NAME, aws_server_
         
         ## if it's an incremental load by datetime, it must be sorted by that datetime
         ## in asc ordering as its primary sort
-        if datetime_index is not None and sorts[0] != datetime_index and sorts[0].lower() != datetime_index.lower() + ' asc':
+        if is_incremental_extraction and sorts[0] != datetime_index and sorts[0].lower() != datetime_index.lower() + ' asc':
             raise ValueError("For an incremental job, the first sort must be the metadata.datetime field ASC")
 
         ## hit the Looker API

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='looker_ingestion',
-    version='1.1.1',
+    version='1.1.2',
     description='Extracts adhoc queries from the Looker API to S3',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This was running without a datetime filter on our instance, and I found it's because this IF statement wasn't right.
I tested and it brought back the filter:
<img width="1107" alt="Screen Shot 2022-01-26 at 11 42 08 PM" src="https://user-images.githubusercontent.com/46604073/151293473-fc2049b3-c517-4972-8f9f-9511cda5a249.png">

