### PR TITLE
Allow for more efficient s3 parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.3] - 2022-01-03
+
+- Find the most recent S3 file when parsing to save memory
+
 ## [1.1.2] - 2022-01-03
 
 - Bug fix: doesn't run the filter at the right time

--- a/looker_ingestion/load_s3.py
+++ b/looker_ingestion/load_s3.py
@@ -54,11 +54,13 @@ def find_existing_data(prefix, s3_bucket, aws_server_public_key=None, aws_server
 
     json_row_objects = []
     response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=prefix)
-    ### if this is the first goaround
+    
+    ### if this is the first goaround, return an empty []
+    
     try:
         all = response['Contents']
     except KeyError:
-        return {}
+        return json_row_objects
     most_recent_file = max(all, key=lambda x: x['LastModified'])
 
     content_object = s3_storage.Object(s3_bucket, most_recent_file["Key"])

--- a/looker_ingestion/load_s3.py
+++ b/looker_ingestion/load_s3.py
@@ -8,15 +8,22 @@ import json
 import logging
 import csv
 
-def load_object_to_s3(data, local_file_name, output_filename, s3_bucket, 
-                    aws_server_public_key=None, aws_server_secret_key=None):
-    """ This saves a json, list of json, or CSV object
+
+def load_object_to_s3(
+    data,
+    local_file_name,
+    output_filename,
+    s3_bucket,
+    aws_server_public_key=None,
+    aws_server_secret_key=None,
+):
+    """This saves a json, list of json, or CSV object
     locally to a temporary file and then uploads it to the S3 bucket"""
 
     temp_dir = tempfile.TemporaryDirectory()
     input_filename = os.path.join(temp_dir.name, local_file_name)
     ## allow for it to be csv
-    with open(input_filename, 'w') as f:
+    with open(input_filename, "w") as f:
         if isinstance(data, dict) or isinstance(data, list):
             json.dump(data, f)
         else:
@@ -33,45 +40,51 @@ def load_object_to_s3(data, local_file_name, output_filename, s3_bucket,
     if os._exists(temp_dir.name):
         shutil.rmtree(temp_dir.name)
 
+
 def create_session(aws_server_public_key, aws_server_secret_key):
-    """ If AWS credentials are passed, create a session with them """
+    """If AWS credentials are passed, create a session with them"""
 
     return boto3.Session(
         aws_access_key_id=aws_server_public_key,
         aws_secret_access_key=aws_server_secret_key,
     )
 
-def find_existing_data(prefix, s3_bucket, aws_server_public_key=None, aws_server_secret_key=None):
-    """ Given a key within an S3 buckets, find the most recently stored file and its greatest metadata date"""
-    
+
+def find_existing_data(
+    prefix, s3_bucket, aws_server_public_key=None, aws_server_secret_key=None
+):
+    """Given a key within an S3 buckets, find the most recently stored file and its greatest metadata date"""
+
     if aws_server_public_key is not None:
         session = create_session(aws_server_public_key, aws_server_secret_key)
         s3_storage = session.resource("s3")
+        s3_client = session.client("s3")
     else:
         s3_storage = boto3.resource("s3")
-    
-    s3_client = boto3.client('s3')
+        s3_client = boto3.client("s3")
 
     json_row_objects = []
     response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=prefix)
-    
+
     ### if this is the first goaround, return an empty []
-    
+
     try:
-        all = response['Contents']
+        all = response["Contents"]
     except KeyError:
         return json_row_objects
-    most_recent_file = max(all, key=lambda x: x['LastModified'])
+    most_recent_file = max(all, key=lambda x: x["LastModified"])
 
     content_object = s3_storage.Object(s3_bucket, most_recent_file["Key"])
-    file_content = content_object.get()['Body'].read().decode('utf-8')
-    if content_object.key.endswith('.json'):
+    file_content = content_object.get()["Body"].read().decode("utf-8")
+    if content_object.key.endswith(".json"):
         for line in file_content.splitlines():
             for json_line in json.loads(line):
                 json_row_objects.append(json_line)
-    elif content_object.key.endswith('.csv'):
+    elif content_object.key.endswith(".csv"):
         for row in csv.DictReader(file_content.splitlines(True)):
-            json_row_objects.append({k.lower().strip(): v.strip() for k, v in row.items()})
+            json_row_objects.append(
+                {k.lower().strip(): v.strip() for k, v in row.items()}
+            )
     else:
         logging.info("Found file of invalid type, not processing for most recent date")
     return json_row_objects

--- a/looker_ingestion/sync_data.py
+++ b/looker_ingestion/sync_data.py
@@ -150,13 +150,14 @@ def extract_data(json_filename, aws_storage_bucket_name=BUCKET_NAME, aws_server_
                 default_days = 1
             else:
                 default_days = int(default_days)
-            date_filter = find_last_date(file_prefix, datetime_index, default_days, aws_storage_bucket_name, aws_server_public_key, aws_server_secret_key)
-            filters[datetime_index] = f"{date_filter}"
         
         ## if it's an incremental load by datetime, it must be sorted by that datetime
         ## in asc ordering as its primary sort
         if is_incremental_extraction and sorts[0] != datetime_index and sorts[0].lower() != datetime_index.lower() + ' asc':
             raise ValueError("For an incremental job, the first sort must be the metadata.datetime field ASC")
+        else:
+            date_filter = find_last_date(file_prefix, datetime_index, default_days, aws_storage_bucket_name, aws_server_public_key, aws_server_secret_key)
+            filters[datetime_index] = f"{date_filter}"
 
         ## hit the Looker API
         write_query = looker_sdk.models.WriteQuery(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3
 looker_sdk
 pytest
 moto
+tzutc

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ boto3
 looker_sdk
 pytest
 moto
-tzutc
+python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ boto3
 looker_sdk
 pytest
 moto
-python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='looker_ingestion',
-    version='1.1.2',
+    version='1.1.3',
     description='Extracts adhoc queries from the Looker API to S3',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_load_s3.py
+++ b/tests/test_load_s3.py
@@ -55,10 +55,12 @@ def test_find_existing_data():
 
     ## pick the only file in there
     s3.put_object(Bucket="databucket", Key="json/looker_output.json", Body=json.dumps(file_contents_json))
+    print(s3.get_object(Bucket="databucket", Key="json/looker_output.json"))
     assert load_s3.find_existing_data("json/looker_output.json", "databucket") == file_contents_json
     
     ## pick the newer file in there
     s3.put_object(Bucket="databucket", Key="json/looker_output2.json", Body=json.dumps(second_file_contents_json))
+    print(s3.get_object(Bucket="databucket", Key="json/looker_output2.json"))
     assert load_s3.find_existing_data("json/looker_output", "databucket") ==  second_file_contents_json
 
     ## initially empty

--- a/tests/test_load_s3.py
+++ b/tests/test_load_s3.py
@@ -62,7 +62,7 @@ def test_find_existing_data():
     s3.create_bucket(Bucket="databucket")
 
     ## initially empty
-    assert load_s3.find_existing_data("json/looker_output.json", "databucket") == {}
+    assert load_s3.find_existing_data("json/looker_output.json", "databucket") == []
 
     ## pick the only file in there
     s3.put_object(
@@ -77,7 +77,7 @@ def test_find_existing_data():
     )
 
     ## initially empty
-    assert load_s3.find_existing_data("csv/looker_output.csv", "databucket") == {}
+    assert load_s3.find_existing_data("csv/looker_output.csv", "databucket") == []
     s3.put_object(
         Bucket="databucket", Key="csv/looker_output.csv", Body=file_contents_csv
     )

--- a/tests/test_load_s3.py
+++ b/tests/test_load_s3.py
@@ -4,7 +4,6 @@ from moto import mock_s3
 import sys
 import json 
 import datetime
-from dateutil.tz import tzutc
 
 currentdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(currentdir)
@@ -55,16 +54,16 @@ def test_find_existing_data():
     assert load_s3.find_existing_data("json/looker_output.json", "databucket") == {}
 
     ## pick the only file in there
-    s3.put_object(Bucket="databucket", Key="json/looker_output.json", Body=json.dumps(file_contents_json), LastModified= datetime.datetime(2021, 12, 30, 23, 40, 36, tzinfo=tzutc()))
+    s3.put_object(Bucket="databucket", Key="json/looker_output.json", Body=json.dumps(file_contents_json))
     assert load_s3.find_existing_data("json/looker_output.json", "databucket") == file_contents_json
     
     ## pick the newer file in there
-    s3.put_object(Bucket="databucket", Key="json/looker_output2.json", Body=json.dumps(second_file_contents_json), LastModified= datetime.datetime(2022, 1, 30, 23, 40, 36, tzinfo=tzutc()))
+    s3.put_object(Bucket="databucket", Key="json/looker_output2.json", Body=json.dumps(second_file_contents_json))
     assert load_s3.find_existing_data("json/looker_output", "databucket") ==  second_file_contents_json
 
     ## initially empty
     assert load_s3.find_existing_data("csv/looker_output.csv", "databucket") == {}
-    s3.put_object(Bucket="databucket", Key="csv/looker_output.csv", Body=file_contents_csv, LastModified= datetime.datetime(2021, 12, 30, 23, 40, 36, tzinfo=tzutc()))
+    s3.put_object(Bucket="databucket", Key="csv/looker_output.csv", Body=file_contents_csv)
     assert load_s3.find_existing_data("csv/looker_output.csv", "databucket") == first_csv_results
-    s3.put_object(Bucket="databucket", Key="csv/looker_output2.csv", Body=second_file_contents_csv, LastModified= datetime.datetime(2022, 1, 30, 23, 40, 36, tzinfo=tzutc()))
+    s3.put_object(Bucket="databucket", Key="csv/looker_output2.csv", Body=second_file_contents_csv)
     assert load_s3.find_existing_data("csv/looker_output", "databucket") ==  second_csv_results

--- a/tests/test_load_s3.py
+++ b/tests/test_load_s3.py
@@ -4,7 +4,7 @@ from moto import mock_s3
 import sys
 import json 
 import datetime
-import tzutc
+from dateutil.tz import tzutc
 
 currentdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(currentdir)

--- a/tests/test_load_s3.py
+++ b/tests/test_load_s3.py
@@ -70,7 +70,7 @@ def test_find_existing_data():
         Key="json/looker_output.json",
         Body=json.dumps(file_contents_json),
     )
-    print(s3.get_object(Bucket="databucket", Key="json/looker_output.json"))
+    
     assert (
         load_s3.find_existing_data("json/looker_output.json", "databucket")
         == file_contents_json
@@ -93,7 +93,7 @@ def test_find_existing_data():
         Key="json/looker_output2.json",
         Body=json.dumps(second_file_contents_json),
     )
-    print(s3.get_object(Bucket="databucket", Key="json/looker_output2.json"))
+    
     assert (
         load_s3.find_existing_data("json/looker_output", "databucket")
         == second_file_contents_json

--- a/tests/test_load_s3.py
+++ b/tests/test_load_s3.py
@@ -2,8 +2,8 @@ import boto3
 import os
 from moto import mock_s3
 import sys
-import json 
-import datetime
+import json
+import time
 
 currentdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(currentdir)
@@ -13,28 +13,36 @@ sys.path.append(looker_ingestion_dir)
 
 from looker_ingestion import load_s3
 
+
 @mock_s3
 def test_load_object_to_s3():
-    """ Ensure that load_object_to_s3 can upload a JSON document to S3 """
+    """Ensure that load_object_to_s3 can upload a JSON document to S3"""
     s3 = boto3.client("s3", region_name="us-east-1")
     bucket_name = "databucket"
     s3.create_bucket(Bucket=bucket_name)
     local_file_name = "looker_query_100"
     output_filename = f"looker/{local_file_name}.json"
-    data = [{"query.id": 123, "query.name": "query_name"}, 
-            {"query.id": 123, "query.name": "query2_name"}]
+    data = [
+        {"query.id": 123, "query.name": "query_name"},
+        {"query.id": 123, "query.name": "query2_name"},
+    ]
     load_s3.load_object_to_s3(data, local_file_name, output_filename, bucket_name)
     obj = s3.get_object(Bucket=bucket_name, Key=output_filename)
-    j = json.loads(obj['Body'].read())
+    j = json.loads(obj["Body"].read())
     assert j == data
+
 
 @mock_s3
 def test_find_existing_data():
-    """ Ensure that find_existing_data can correctly read the most recent JSON or CSV files from S3 """
-    file_contents_json = [{"query.id": 4845015, "history.created_time": "2021-12-02 14:40:18"}, 
-                            {"query.id": 4845015, "history.created_time": "2021-12-02 14:40:20"}]
-    second_file_contents_json = [{"query.id": 4845015, "history.created_time": "2021-12-02 14:40:22"}, 
-                                {"query.id": 4845015, "history.created_time": "2021-12-02 14:40:24"}]
+    """Ensure that find_existing_data can correctly read the most recent JSON or CSV files from S3"""
+    file_contents_json = [
+        {"query.id": 4845015, "history.created_time": "2021-12-02 14:40:18"},
+        {"query.id": 4845015, "history.created_time": "2021-12-02 14:40:20"},
+    ]
+    second_file_contents_json = [
+        {"query.id": 4845015, "history.created_time": "2021-12-02 14:40:22"},
+        {"query.id": 4845015, "history.created_time": "2021-12-02 14:40:24"},
+    ]
 
     file_contents_csv = """Query ID, History Created Time
     845015,2021-12-02 14:40:18
@@ -42,30 +50,59 @@ def test_find_existing_data():
     second_file_contents_csv = """Query ID, History Created Time
     845015,2021-12-02 14:40:22
     845015,2021-12-02 14:40:24"""
-    first_csv_results = [{"query id": '845015', "history created time": "2021-12-02 14:40:18"}, 
-                    {"query id": '845015', "history created time": "2021-12-02 14:40:20"}]
-    second_csv_results = [{"query id": '845015', "history created time": "2021-12-02 14:40:22"}, 
-                    {"query id": '845015', "history created time": "2021-12-02 14:40:24"}
-                    ]
+    first_csv_results = [
+        {"query id": "845015", "history created time": "2021-12-02 14:40:18"},
+        {"query id": "845015", "history created time": "2021-12-02 14:40:20"},
+    ]
+    second_csv_results = [
+        {"query id": "845015", "history created time": "2021-12-02 14:40:22"},
+        {"query id": "845015", "history created time": "2021-12-02 14:40:24"},
+    ]
     s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket="databucket")
-    
+
     ## initially empty
     assert load_s3.find_existing_data("json/looker_output.json", "databucket") == {}
 
     ## pick the only file in there
-    s3.put_object(Bucket="databucket", Key="json/looker_output.json", Body=json.dumps(file_contents_json))
+    s3.put_object(
+        Bucket="databucket",
+        Key="json/looker_output.json",
+        Body=json.dumps(file_contents_json),
+    )
     print(s3.get_object(Bucket="databucket", Key="json/looker_output.json"))
-    assert load_s3.find_existing_data("json/looker_output.json", "databucket") == file_contents_json
-    
-    ## pick the newer file in there
-    s3.put_object(Bucket="databucket", Key="json/looker_output2.json", Body=json.dumps(second_file_contents_json))
-    print(s3.get_object(Bucket="databucket", Key="json/looker_output2.json"))
-    assert load_s3.find_existing_data("json/looker_output", "databucket") ==  second_file_contents_json
+    assert (
+        load_s3.find_existing_data("json/looker_output.json", "databucket")
+        == file_contents_json
+    )
 
     ## initially empty
     assert load_s3.find_existing_data("csv/looker_output.csv", "databucket") == {}
-    s3.put_object(Bucket="databucket", Key="csv/looker_output.csv", Body=file_contents_csv)
-    assert load_s3.find_existing_data("csv/looker_output.csv", "databucket") == first_csv_results
-    s3.put_object(Bucket="databucket", Key="csv/looker_output2.csv", Body=second_file_contents_csv)
-    assert load_s3.find_existing_data("csv/looker_output", "databucket") ==  second_csv_results
+    s3.put_object(
+        Bucket="databucket", Key="csv/looker_output.csv", Body=file_contents_csv
+    )
+    assert (
+        load_s3.find_existing_data("csv/looker_output.csv", "databucket")
+        == first_csv_results
+    )
+    time.sleep(5)
+
+    ## pick the newer file in there
+    s3.put_object(
+        Bucket="databucket",
+        Key="json/looker_output2.json",
+        Body=json.dumps(second_file_contents_json),
+    )
+    print(s3.get_object(Bucket="databucket", Key="json/looker_output2.json"))
+    assert (
+        load_s3.find_existing_data("json/looker_output", "databucket")
+        == second_file_contents_json
+    )
+
+    s3.put_object(
+        Bucket="databucket", Key="csv/looker_output2.csv", Body=second_file_contents_csv
+    )
+    assert (
+        load_s3.find_existing_data("csv/looker_output", "databucket")
+        == second_csv_results
+    )


### PR DESCRIPTION
In this version, we **only** read in data from the most recent (most recently modified) s3 object in order to save memory. Initially, I wanted to be thorough and check all the contents, but ultimately, if your most recent file has an earlier date, likely you are backfilling for a reason.

Ran it twice -- once empty, and once with a date
<img width="957" alt="Screen Shot 2022-04-25 at 9 03 32 PM" src="https://user-images.githubusercontent.com/46604073/165199966-df6e30e5-281c-4c56-bd52-6155b5614251.png">
<img width="1113" alt="Screen Shot 2022-04-25 at 9 03 40 PM" src="https://user-images.githubusercontent.com/46604073/165199971-e4ca688d-33e5-465b-b398-a789fe096665.png">

