### PR TITLE
Update s3 list_objects_v2 api call to support pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.4.0] - 2023-04-13
+
+- Paginating calls to the s3 `list_objects_v2`
+
 ## [1.3.0] - 2023-04-13
 
 - Update to use Looker API 4.0

--- a/looker_ingestion/load_s3.py
+++ b/looker_ingestion/load_s3.py
@@ -59,19 +59,20 @@ def find_existing_data(
         s3_client = boto3.client("s3")
 
     json_row_objects = []
+    files = []
     paginator = s3_client.get_paginator('list_objects_v2')
     for page in paginator.paginate(Bucket=s3_bucket, Prefix=prefix):
         try:
             contents = page["Contents"]
         except KeyError:
             break
-        json_row_objects.extend(contents)
+        files.extend(contents)
 
     ### if this is the first goaround, return an empty []
     if len(json_row_objects) == 0:
         return json_row_objects
 
-    most_recent_file = max(json_row_objects, key=lambda x: x["LastModified"])
+    most_recent_file = max(files, key=lambda x: x["LastModified"])
 
     content_object = s3_storage.Object(s3_bucket, most_recent_file["Key"])
     file_content = content_object.get()["Body"].read().decode("utf-8")

--- a/looker_ingestion/load_s3.py
+++ b/looker_ingestion/load_s3.py
@@ -69,7 +69,7 @@ def find_existing_data(
         files.extend(contents)
 
     ### if this is the first goaround, return an empty []
-    if len(json_row_objects) == 0:
+    if len(files) == 0:
         return json_row_objects
 
     most_recent_file = max(files, key=lambda x: x["LastModified"])

--- a/looker_ingestion/sync_data.py
+++ b/looker_ingestion/sync_data.py
@@ -69,7 +69,11 @@ def find_last_date(
     for row in json_objects:
         if file_prefix.endswith("csv"):
             datetime_index = datetime_index.replace(".", " ").replace("_", " ")
-        last_date = max(last_date, row[datetime_index])
+        try:
+            last_date = max(last_date, row[datetime_index])
+        except KeyError as e:
+            logging.error(f"Key doesn't exist in row {row}")    
+            raise e
     if last_date is None or last_date == [] or last_date == "1990-01-01 00:00:00":
         logging.info(f"No date found; running with {first_date}")
         last_date = (datetime.now() - timedelta(days=default_days)).strftime(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="looker_ingestion",
-    version="1.3.0",
+    version="1.4.0",
     description="Extracts adhoc queries from the Looker API to S3",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The [list_objects_v2 method](https://boto3.amazonaws.com/v1/documentation/api/1.26.93/reference/services/s3/client/list_objects_v2.html#list-objects-v2) has a max results parameter that defaults to 1000. When we exceeded that number for the query history api the extract method kept getting the same "most recent file" and then would try to pull the same date range of data from the API.

This uses the [boto3 pagination](https://boto3.amazonaws.com/v1/documentation/api/1.26.93/reference/services/s3/paginator/ListObjectsV2.html) to get a full list of all the s3 files instead of directly using the `list_objects_v2` method.