### PR TITLE
Update unit tests to support moto 5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.4.2] - 2024-05-01
+
+- Update unit tests to work with `moto` 5.0+
+
 ## [1.4.1] - 2024-05-01
 
 - Use `models40` for `WriteQuery`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3
 looker_sdk
 pytest
-moto
+moto>=5.0
 smart_open

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     install_requires=["boto3", "looker_sdk", "smart_open"],
     setup_requires=["pytest-runner"],
-    tests_require=["pytest", "moto"],
+    tests_require=["pytest", "moto>=5.0"],
     classifiers=[
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="looker_ingestion",
-    version="1.4.1",
+    version="1.4.2",
     description="Extracts adhoc queries from the Looker API to S3",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_load_s3.py
+++ b/tests/test_load_s3.py
@@ -1,6 +1,6 @@
 import boto3
 import os
-from moto import mock_s3
+from moto import mock_aws
 import sys
 import json
 import time
@@ -14,7 +14,7 @@ sys.path.append(looker_ingestion_dir)
 from looker_ingestion import load_s3
 
 
-@mock_s3
+@mock_aws
 def test_load_object_to_s3():
     """Ensure that load_object_to_s3 can upload a JSON document to S3"""
     s3 = boto3.client("s3", region_name="us-east-1")
@@ -32,7 +32,7 @@ def test_load_object_to_s3():
     assert j == data
 
 
-@mock_s3
+@mock_aws
 def test_find_existing_data():
     """Ensure that find_existing_data can correctly read the most recent JSON or CSV files from S3"""
     file_contents_json = [


### PR DESCRIPTION
CI is failing to deploy because `moto` is not pinned and `moto` 5.0+ had a breaking change.

This PR:
- Pins `moto` to 5.0+
- Updates the failing unit test to support this version of `moto`.